### PR TITLE
fix: support of key Identifiers in ObjectProperty

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const visit = (node) => {
       break
     case 'Property':
       node.kind = 'init'
+      visit(node.key)
       visit(node.value)
       break
     case 'Identifier':


### PR DESCRIPTION
In object like this:

```js
{
   "hello": "world" 
}
```

`"hello"` parsed as:

```js
{
  type: 'Identifier',
  value: 'hello',
  raw: '"hello"',
  loc: {
    start: { line: 2, column: 5, offset: 6 },
    end: { line: 2, column: 12, offset: 13 },
    source: null
  }
}
```

So it should be updated to.